### PR TITLE
Adding css for the scrollbar effecting the page width

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -61,6 +61,7 @@ dl, dd, ol, ul, figure {
  */
 html, body {
     height: 100%;
+    overflow-y: overlay
 }
 body {
     font: $base-font-weight #{$base-font-size}/#{$base-line-height} $base-font-family;


### PR DESCRIPTION
In chrome on pages without a scrollbar have a different width than pages that need a scrollbar. This causes the text in the page to slightly shift when going to a page with a scrollbar from one without. This makes the page transition look a bit smoother.